### PR TITLE
one "router dealer" socket instead of n "push pull"

### DIFF
--- a/packaged/src/log/handler.c
+++ b/packaged/src/log/handler.c
@@ -268,8 +268,14 @@ bxierr_p _bind_data_zocket(bxilog_handler_p handler,
     bxiassert(NULL == data->data_zocket);
 
     err2 = bxizmq_zocket_create(BXILOG__GLOBALS->zmq_ctx,
-                                ZMQ_PULL,
+                                ZMQ_DEALER,
                                 &data->data_zocket);
+    BXIERR_CHAIN(err, err2);
+
+    err2 = bxizmq_zocket_setopt(data->data_zocket,
+                                ZMQ_IDENTITY,
+                                &param->rank,
+                                sizeof(param->rank));
     BXIERR_CHAIN(err, err2);
 
     err2 = bxizmq_zocket_setopt(data->data_zocket,

--- a/packaged/src/log/remote_receiver.c
+++ b/packaged/src/log/remote_receiver.c
@@ -600,14 +600,19 @@ bxierr_p _dispatch_log_record(tsd_p tsd, bxilog_record_p record, size_t data_len
     for (size_t i = 0; i < BXILOG__GLOBALS->internal_handlers_nb; i++) {
       // Send the frame
       // normal version if record comes from the stack 'buf'
+      err2 = bxizmq_data_snd(&i, sizeof(i),
+                             tsd->data_channel, ZMQ_DONTWAIT|ZMQ_SNDMORE,
+                             BXILOG_RECEIVER_RETRIES_MAX,
+                             BXILOG_RECEIVER_RETRY_DELAY);
+      BXIERR_CHAIN(err, err2);
       err2 = bxizmq_data_snd(record, data_len,
-                             tsd->data_channel[i], ZMQ_DONTWAIT,
+                             tsd->data_channel, ZMQ_DONTWAIT,
                              BXILOG_RECEIVER_RETRIES_MAX,
                              BXILOG_RECEIVER_RETRY_DELAY);
 
       // Zero-copy version (if record has been mallocated).
       //            err2 = bxizmq_data_snd_zc(record, data_len,
-      //                                      tsd->data_channel[i], ZMQ_DONTWAIT,
+      //                                      tsd->data_channel, ZMQ_DONTWAIT,
       //                                      RETRIES_MAX, RETRY_DELAY,
       //                                      bxizmq_data_free, NULL);
       BXIERR_CHAIN(err, err2);

--- a/packaged/src/log/tsd.c
+++ b/packaged/src/log/tsd.c
@@ -57,11 +57,8 @@ void bxilog__tsd_free(void * const data) {
 
     if (NULL != tsd->data_channel) {
         bxierr_p err = BXIERR_OK, err2;
-        for (size_t i = 0; i < BXILOG__GLOBALS->config->handlers_nb; i++) {
-            err2 = bxizmq_zocket_destroy(&tsd->data_channel[i]);
-            BXIERR_CHAIN(err, err2);
-        }
-        BXIFREE(tsd->data_channel);
+        err2 = bxizmq_zocket_destroy(&tsd->data_channel);
+        BXIERR_CHAIN(err, err2);
         err2 = bxizmq_zocket_destroy(&tsd->ctrl_channel);
         BXIERR_CHAIN(err, err2);
         if (bxierr_isko(err)) bxierr_report(&err, STDERR_FILENO);
@@ -107,10 +104,6 @@ bxierr_p bxilog__tsd_get(tsd_p * result) {
     bxiassert(NULL != BXILOG__GLOBALS->config->handlers);
     bxiassert(0 < BXILOG__GLOBALS->config->tsd_log_buf_size);
     tsd->log_buf = bximem_calloc(BXILOG__GLOBALS->config->tsd_log_buf_size);
-    if (0 != BXILOG__GLOBALS->config->handlers_nb) {
-        tsd->data_channel = bximem_calloc(BXILOG__GLOBALS->config->handlers_nb * 
-                                          sizeof(*tsd->data_channel));
-    }
 
     bxierr_list_p errlist = bxierr_list_new();
     for (size_t i = 0; i < BXILOG__GLOBALS->config->handlers_nb; i++) {
@@ -118,18 +111,20 @@ bxierr_p bxilog__tsd_get(tsd_p * result) {
         bxiassert(NULL != url);
         bxierr_p err = BXIERR_OK, err2;
 
-        err2 = bxizmq_zocket_create(BXILOG__GLOBALS->zmq_ctx,
-                                    ZMQ_PUSH,
-                                    &tsd->data_channel[i]);
-        BXIERR_CHAIN(err, err2);
+        if (NULL == tsd->data_channel) {
+            err2 = bxizmq_zocket_create(BXILOG__GLOBALS->zmq_ctx,
+                                        ZMQ_ROUTER,
+                                        &tsd->data_channel);
+            BXIERR_CHAIN(err, err2);
 
-        err2 = bxizmq_zocket_setopt(tsd->data_channel[i],
-                                    ZMQ_SNDHWM,
-                                    &BXILOG__GLOBALS->config->data_hwm,
-                                    sizeof(BXILOG__GLOBALS->config->data_hwm));
-        BXIERR_CHAIN(err, err2);
+            err2 = bxizmq_zocket_setopt(tsd->data_channel,
+                                        ZMQ_SNDHWM,
+                                        &BXILOG__GLOBALS->config->data_hwm,
+                                        sizeof(BXILOG__GLOBALS->config->data_hwm));
+            BXIERR_CHAIN(err, err2);
+        }
 
-        err2 = bxizmq_zocket_connect(tsd->data_channel[i], url);
+        err2 = bxizmq_zocket_connect(tsd->data_channel, url);
         BXIERR_CHAIN(err, err2);
 
         url = BXILOG__GLOBALS->config->handlers_params[i]->ctrl_url;
@@ -139,17 +134,16 @@ bxierr_p bxilog__tsd_get(tsd_p * result) {
                                         ZMQ_REQ,
                                         &tsd->ctrl_channel);
             BXIERR_CHAIN(err, err2);
-        }
 
-        err2 = bxizmq_zocket_setopt(tsd->ctrl_channel,
-                                    ZMQ_SNDHWM,
-                                    &BXILOG__GLOBALS->config->ctrl_hwm,
-                                    sizeof(BXILOG__GLOBALS->config->ctrl_hwm));
-        BXIERR_CHAIN(err, err2);
+            err2 = bxizmq_zocket_setopt(tsd->ctrl_channel,
+            	                        ZMQ_SNDHWM,
+                                        &BXILOG__GLOBALS->config->ctrl_hwm,
+                                        sizeof(BXILOG__GLOBALS->config->ctrl_hwm));
+            BXIERR_CHAIN(err, err2);
+        }
 
         err2 = bxizmq_zocket_connect(tsd->ctrl_channel, url);
         BXIERR_CHAIN(err, err2);
-
         if (bxierr_isko(err)) bxierr_list_append(errlist, err);
     }
 

--- a/packaged/src/log/tsd_impl.h
+++ b/packaged/src/log/tsd_impl.h
@@ -35,7 +35,7 @@ struct tsd_s {
     size_t sum_log_size;
 
     char *  log_buf;                 // The per-thread log buffer
-    void ** data_channel;             // The thread-specific zmq logging socket;
+    void * data_channel;             // The thread-specific zmq logging socket;
     void *  ctrl_channel;             // The thread-specific zmq controlling socket;
 #ifdef __linux__
     pid_t tid;                      // Cache the tid on Linux since we assume NPTL


### PR DESCRIPTION
The previous designed uses many sockets and was a workaround. This version is better in design point of view and improves the scalability (with 300 threads previously we reach the limit of 1024 opened files).