### PR TITLE
BXIMEM_CALLOC shorthand macro

### DIFF
--- a/packaged/include/bxi/base/mem.h
+++ b/packaged/include/bxi/base/mem.h
@@ -84,6 +84,16 @@
 void * bximem_calloc(size_t n);
 
 /**
+ * Short-usage macro for bximem_calloc.
+ * Usage:
+ *     BXIMEM_CALLOC(already_declared_obj, nb_elements);
+ * or  type BXIMEM_CALLOC(new_obj, nb_elements);
+ */
+#define BXIMEM_CALLOC(POINTER, N_ELTS) \
+    (POINTER) = bximem_calloc(sizeof(*(POINTER)) \
+                                * (size_t)(N_ELTS))
+
+/**
  * Replaces realloc().
  *
  * Same usage as realloc(). A check is performed to ensure the returned pointer


### PR DESCRIPTION
This allows simplifying allocations in most cases.

Usage:

    BXIMEM_CALLOC(already_declared_obj, nb_elements);
    // <=> already_declared_obj = bximem_calloc((size_t)(nb_elements)
                                                * sizeof(*already_declared_obj));

Or

    type BXIMEM_CALLOC(new_obj, nb_elements);
    // <=> type new_obj = bximem_calloc((size_t)(nb_elements) * sizeof(*new_obj));