### PR TITLE
Revert "Merge pull request #28 from zakaria-bendifallah/err_magic_nobt"

### DIFF
--- a/bxibase.spec
+++ b/bxibase.spec
@@ -284,8 +284,3 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 ## Do not add anything after the following line!
 ##################################################
 %changelog
-
-* Wed Feb 19 2018 BXIHL Team <bxihl@atos.net> - 9.0.1:
-[feature] Add the possiblity to raise an error without associating a backtrace to it
-
-

--- a/packaged/include/bxi/base/err.h
+++ b/packaged/include/bxi/base/err.h
@@ -185,10 +185,6 @@
 #define BXIERR_ALL_CAUSES 64
 #define ERR2STR_MAX_SIZE 1024
 
-/**
- * Define a code to disable the inclusion of the Backtrace in the error instance 
- */
-#define BXIERR_NOBT_CODE "NOBT"
 
 /**
  * Chain the new error with the current one and adapt the current error accordingly.
@@ -243,19 +239,6 @@
  * @see bxierr_simple()
  */
 #define bxierr_gen(...) bxierr_simple(BXIERR_GENERIC_CODE, __VA_ARGS__)
-
-
-/**
- * Create a generic error, with the given printf-like message and no backtrace.
- *
- * @note: the underlying call to bxierr_new introduces a magic parameter 
- *        "BXIERR_NOBT_CODE" to disable the inclusion of the Backtrace. 
- *        See the definition of bxierr_new function for more information
- *        on how the parameter is handled
- * @see bxierr_new()
- */
-#define bxierr_gen_nobt(...) bxierr_new(BXIERR_GENERIC_CODE, NULL, NULL, NULL, NULL, \
-                                        BXIERR_NOBT_CODE, __VA_ARGS__) 
 
 /**
  * Define an error with the given code and the given error list.

--- a/packaged/src/err.c
+++ b/packaged/src/err.c
@@ -91,8 +91,9 @@ bxierr_p bxierr_new(int code,
 
     bxierr_p self = bximem_calloc(sizeof(*self));
     self->code = code;
-    self->backtrace_len = 0;
-    self->backtrace = NULL;
+    char * tmp = NULL;
+    self->backtrace_len = bxierr_backtrace_str(&tmp);
+    self->backtrace = tmp;
     self->data = data;
     self->free_fn = free_fn;
     self->add_to_report = (NULL == add_to_report) ?
@@ -110,21 +111,8 @@ bxierr_p bxierr_new(int code,
     }
 
     va_list ap;
-    va_start(ap,fmt);
-    const char * real_fmt = NULL;
-    // special test: where a magic parameter BXIERR_NOBT_CODE is supplied
-    // in the location of fmt to deactivate the backtrace, in this case the 
-    // real fmt would be the first parameter in the va_list  
-    if ((fmt != NULL) &&  strcmp(fmt, BXIERR_NOBT_CODE) != 0) {
-        char * tmp = NULL;
-        self->backtrace_len = bxierr_backtrace_str(&tmp);
-        self->backtrace = tmp; 
-        real_fmt = fmt;        
-    } else {
-        real_fmt = va_arg(ap, char*);
-    }
-    
-    self->msg_len = bxistr_vnew(&self->msg, real_fmt, ap);
+    va_start(ap, fmt);
+    self->msg_len = bxistr_vnew(&self->msg, fmt, ap);
     va_end(ap);
 
     return self;


### PR DESCRIPTION
The no backtrace implementation with advanced use of va_args is not well handled by older versions of GCC.
Another solution need to be developped

This reverts commit d44507266caec9cb10b103425acae8710875e1ed, reversing
changes made to c783e9e8923d16ece76fff8898183b66bf36646d.